### PR TITLE
Remove CLAUDE.md reference from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ Complete removal with dependency tracking:
 
 - Full documentation: `doc/README.md`
 - Manual page: `man termgpt` (after installation)
-- Development guide: `CLAUDE.md`
 
 ## License
 


### PR DESCRIPTION
Remove reference to development guide since CLAUDE.md is now in .gitignore for privacy.